### PR TITLE
Agregar promocion

### DIFF
--- a/force-app/main/default/classes/PRO_PromocionesCtrl.cls
+++ b/force-app/main/default/classes/PRO_PromocionesCtrl.cls
@@ -894,7 +894,7 @@ public with sharing class PRO_PromocionesCtrl {
 
 			promocion = (Promocion__c)JSON.deserialize(jsonPromotion,Promocion__c.class);
 			System.debug('upsertPromotionAndConfigurator || Promocion__c: ' + promocion);
-			Catalogo__c catalogo =  [SELECT Id,Name FROM Catalogo__c WHERE Id =: promocion.NombreConcepto__c];
+			Catalogo__c catalogo =  [SELECT Id, Name, HeredarCantidadPagosColegiaturaOE__c, HeredarCantidadPagosInscripcionOE__c  FROM Catalogo__c WHERE Id =: promocion.NombreConcepto__c];
 			System.debug('upsertPromotionAndConfigurator || catalogo: ' + catalogo);
             //System.debug('upsertPromotionAndConfigurator || Promocion.Id :' + promocion.Id);
 			//update promocion;
@@ -1131,6 +1131,7 @@ public with sharing class PRO_PromocionesCtrl {
 
 			Database.rollback(sp);
 
+			//throw ex;
 			String error = 'Exception Promociones-upsertPromotionAndConfigurator linea:'+ex.getLineNumber()+ ' motivo:'+ex.getCause()+ '/'+ ex.getMessage();
 
 			mapResponse.put('state', 'Exception');

--- a/force-app/main/default/classes/PRO_PromocionesCtrl.cls
+++ b/force-app/main/default/classes/PRO_PromocionesCtrl.cls
@@ -905,9 +905,8 @@ public with sharing class PRO_PromocionesCtrl {
             if(pC.size() > 0 && pC != null){
                 for(ConfiguradorPromocion__c cP : pC){
 
-                    if( (catalogo.Name == 'Colegiatura' || catalogo.Name == 'Reinscripción') 
-                    && promocion.SeleccionarCantidadPagosOE__c 
-                    && promocion.SeleccionarCantidadPagosOE__c == true ){
+                    if( ((catalogo.Name == 'Colegiatura' || catalogo.Name == 'Reinscripción') && promocion.SeleccionarCantidadPagosOE__c == true)
+					|| promocion.SeleccionarCantidadPagosOE__c == true ){
                         System.debug('upsertPromotionAndConfigurator::EsColegiaturaInscripcion1');
                         if( !periodos.contains(cP.Periodo__c) ){
                             periodos.add(cP.Periodo__c);
@@ -941,8 +940,8 @@ public with sharing class PRO_PromocionesCtrl {
             }else{
                 for(ConfiguradorPromocion__c cP : jsonConfigurator){
 
-                    if( promocion.SeleccionarCantidadPagosOE__c 
-                    && promocion.SeleccionarCantidadPagosOE__c == true ){
+                    if( ((catalogo.Name == 'Colegiatura' || catalogo.Name == 'Reinscripción') && promocion.SeleccionarCantidadPagosOE__c == true)
+					|| promocion.SeleccionarCantidadPagosOE__c == true ){
                         System.debug('upsertPromotionAndConfigurator::EsColegiaturaInscripcion1');
                         if( !periodos.contains(cP.Periodo__c) ){
                             periodos.add(cP.Periodo__c);
@@ -978,8 +977,8 @@ public with sharing class PRO_PromocionesCtrl {
 
 
 			
-			if(    promocion.SeleccionarCantidadPagosOE__c 
-			&& promocion.SeleccionarCantidadPagosOE__c == true ){
+			/* if(((catalogo.Name == 'Colegiatura' || catalogo.Name == 'Reinscripción') && promocion.SeleccionarCantidadPagosOE__c == true)
+			|| promocion.SeleccionarCantidadPagosOE__c == true ){
 				System.debug('upsertPromotionAndConfigurator::EsColegiaturaInscripcion2');
                 System.debug('$$$$ programas' + programas);
 				List<OfertaEducativa__c> ofertaE = [select Periodo__c, Modalidad__c, Plantel__c, Nivel__c, Programa__c, NumeroColegiaturas__c, NumeroInscripciones__c from OfertaEducativa__c WHERE Periodo__c IN: periodos AND Modalidad__c IN: modalidades AND Plantel__c IN: planteles AND Nivel__c IN: niveles AND Programa__c IN: programas];
@@ -995,6 +994,8 @@ public with sharing class PRO_PromocionesCtrl {
 						mapOfertaEducativa.put(keymap,oe);
 					}
 				}
+
+				
 				System.debug('upsertPromotionAndConfigurator::mapOfertaEducativa' + mapOfertaEducativa);
                 System.debug('$$$$ confPromocion' + confPromocion);
 				if( ofertaE != null && ofertaE.size() > 0){
@@ -1011,7 +1012,55 @@ public with sharing class PRO_PromocionesCtrl {
 								if(mapOfertaEducativa.containsKey(keyConfigurado)){
 									confPromo.CantidadPago__c = mapOfertaEducativa.get(keyConfigurado).NumeroInscripciones__c;
 								}
-							}*/
+							}*
+
+					}
+					
+				}
+
+			}  */
+			if(   ((catalogo.Name == 'Colegiatura' || catalogo.Name == 'Reinscripción') && promocion.SeleccionarCantidadPagosOE__c == true)
+				|| promocion.SeleccionarCantidadPagosOE__c == true ){
+				System.debug('upsertPromotionAndConfigurator::EsColegiaturaInscripcion2');
+				List<OfertaEducativa__c> ofertaE = [select Periodo__c, Modalidad__c, Plantel__c, Nivel__c, Programa__c, NumeroColegiaturas__c, NumeroInscripciones__c from OfertaEducativa__c WHERE Periodo__c IN: periodos AND Modalidad__c IN: modalidades AND Plantel__c IN: planteles AND Nivel__c IN: niveles AND Programa__c IN: programas];
+
+				promocion.PagoDiferido__c = false;
+				promocion.PagoUnico__c = false;
+				
+				map<String,OfertaEducativa__c> mapOfertaEducativa = new map<String,OfertaEducativa__c>();
+				for(OfertaEducativa__c oe : ofertaE){
+					String keymap = '' + oe.Periodo__c +oe.Modalidad__c + oe.Plantel__c +  oe.Nivel__c + oe.Programa__c;
+					if(!mapOfertaEducativa.containsKey(keymap)){
+						mapOfertaEducativa.put(keymap,oe);
+					}
+				}
+				System.debug('upsertPromotionAndConfigurator::mapOfertaEducativa' + mapOfertaEducativa);
+				if( ofertaE != null && ofertaE.size() > 0){
+
+					for( ConfiguradorPromocion__c confPromo : confPromocion ){
+						string keyConfigurado = '' + confPromo.Periodo__c +confPromo.Modalidad__c + confPromo.Plantel__c +  confPromo.Nivel__c + confPromo.Programa__c;
+							if(catalogo.Name == 'Colegiatura'){
+								if(mapOfertaEducativa.containsKey(keyConfigurado)){
+									confPromo.CantidadPago__c = mapOfertaEducativa.get(keyConfigurado).NumeroColegiaturas__c;
+								}
+							}
+							else if(catalogo.Name == 'Reinscripción'){
+								if(mapOfertaEducativa.containsKey(keyConfigurado)){
+									confPromo.CantidadPago__c = mapOfertaEducativa.get(keyConfigurado).NumeroInscripciones__c;
+								}
+							}
+							else{
+								if(catalogo.HeredarCantidadPagosColegiaturaOE__c == true){
+									if(mapOfertaEducativa.containsKey(keyConfigurado)){
+										confPromo.CantidadPago__c = mapOfertaEducativa.get(keyConfigurado).NumeroColegiaturas__c;
+									}
+								}
+								if(catalogo.HeredarCantidadPagosInscripcionOE__c == true){
+									if(mapOfertaEducativa.containsKey(keyConfigurado)){
+										confPromo.CantidadPago__c = mapOfertaEducativa.get(keyConfigurado).NumeroInscripciones__c;
+									}
+								}
+							}
 
 					}
 					

--- a/force-app/main/default/components/PRO_AgregarPromocion.component
+++ b/force-app/main/default/components/PRO_AgregarPromocion.component
@@ -617,7 +617,7 @@
 
 								</div>
 
-								<div class="form-group" ng-if="pro.colegiaturaInscripcion">
+								<div class="form-group" ng-if="pro.muestra_seleccionar_pagos_oe">
 
 									<div class="col-12">
 
@@ -683,8 +683,7 @@
 											ctc-min-number="1" 
 											ctc-max-number="100" 
 											ctc-field="{precision:12,scale:0,type:'number', decimalsView:0}"
-											ng-disabled="pro.asignarPromocion.cantidadPagosOE || pro.asignarPromocion.NOEditable || pro.asignarPromocion.pagoUnico || pro.colegiaturaInscripcion || pro.asignarPromocion.isGranted || pro.asignarPromocion.Id !== ''"/>
-											
+											ng-disabled="pro.asignarPromocion.cantidadPagosOE || pro.asignarPromocion.NOEditable || pro.asignarPromocion.pagoUnico || pro.colegiaturaInscripcion || pro.asignarPromocion.isGranted"/>
 										<div ng-messages="addPromotionForm.cantidadPagos.$error">
 												<div ng-message="required" class="requiredInput">Requerido*</div>
 										</div> 
@@ -745,7 +744,7 @@
 								
 							</div>
 							
-							<div ng-show="pro.asignarPromocion.pagoDiferido">
+							<div ng-if="pro.asignarPromocion.pagoDiferido">
 								<div class="form-group row">
 
 									<label for="inlineFormInputConceptName" class="col-md-5">Periodicidad</label>
@@ -753,14 +752,14 @@
 									<div class="col-md-7">
 										
 										<select id="inlineFormInputPeriodicidad" 
-																	class="form-control form-control-sm" 
-																	style="width: 86%;" 
-																	name="periodicidadPromocion"
-																		ng-options="optionPeriodicidad as optionPeriodicidad.Name for optionPeriodicidad in pro.periodicidadList"
-																		ng-model="pro.asignarPromocion.periodicidad" 
-																		ng-change="" 
-																		ng-disabled="pro.asignarPromocion.NOEditable || pro.asignarPromocion.isGranted || pro.asignarPromocion.Id !== ''"
-																		required=""/>
+											class="form-control form-control-sm" 
+											style="width: 86%;" 
+											name="periodicidadPromocion"
+												ng-options="optionPeriodicidad as optionPeriodicidad.Name for optionPeriodicidad in pro.periodicidadList"
+												ng-model="pro.asignarPromocion.periodicidad" 
+												ng-change="" 
+												ng-disabled="pro.asignarPromocion.NOEditable || pro.asignarPromocion.isGranted || pro.asignarPromocion.Id !== ''"
+												required=""/>
 
 										<div ng-messages="addPromotionForm.periodicidadList.$error">
 											<!--<div ng-message="required" class="requiredInput">Requerido*</div>-->

--- a/force-app/main/default/pages/PRO_Layout.page
+++ b/force-app/main/default/pages/PRO_Layout.page
@@ -1311,6 +1311,10 @@
 						vm.tipoPagoDiferido = tipoPagoDiferido;
 						vm.pagosOEConcepto = pagosOEConcepto;
 						vm.verificarFechaFin = verificarFechaFin;
+
+
+
+						vm.muestra_seleccionar_pagos_oe = false;
 					/**END Initialization of methods to load Data */
 
 					/*START Init Functions*/
@@ -1625,7 +1629,7 @@
 
 						var deferred = $q.defer();
 
-						$timeout(function(){ 
+						//$timeout(function(){ 
 
 							vm.filterAddPromotion.filterListModality = [];
 							vm.filterAddPromotion.filterListPlantel = [];
@@ -1739,7 +1743,7 @@
 
 							deferred.resolve(vm.filterAddPromotion);
 
-						});
+						//});
 
 						
 						return deferred.promise;
@@ -3385,7 +3389,7 @@
 
                         //vm.asignarPromocion.periodicidad = (promotion.Periodicidad__c) ? promotion.Periodicidad__c : null;
 
-						vm.asignarPromocion.cantidadPagos = (promotion.CantidadPago__c) ? promotion.CantidadPago__c : 0;
+						vm.asignarPromocion.cantidadPagos = (promotion.CantidadPago__c) ? promotion.CantidadPago__c : undefined;
 
 						vm.asignarPromocion.importeConcepto = (promotion.ImporteConcepto__c) ? promotion.ImporteConcepto__c : 0;
 
@@ -3394,7 +3398,7 @@
 						if( promotion.NombreConcepto__r
 						&& ( promotion.NombreConcepto__r.Name == 'Colegiatura' 
 						|| promotion.NombreConcepto__r.Name == 'Reinscripción' ) || promotion.SeleccionarCantidadPagosOE__c){
-
+							proAgP.muestra_seleccionar_pagos_oe = true;
 							vm.colegiaturaInscripcion = true;
 							vm.asignarPromocion.cantidadPagosOE = ( promotion.SeleccionarCantidadPagosOE__c  ) ? promotion.SeleccionarCantidadPagosOE__c : false;
 						}
@@ -3909,6 +3913,7 @@
 						console.log('tipoConcepto::filterAddPromotion::',vm.filterAddPromotion);
 						if (vm.filterAddPromotion && vm.filterAddPromotion.filterProgram && vm.filterAddPromotion.filterProgram.length == 1 && (concepto.HeredarCantidadPagosColegiaturaOE__c == true || concepto.HeredarCantidadPagosInscripcionOE__c == true)) {
 							console.log('tipoConcepto::entraif::');
+							vm.muestra_seleccionar_pagos_oe = true;
 							vm.colegiaturaInscripcion = true;
 							vm.asignarPromocion.cantidadPagosOE = true;
 							vm.asignarPromocion.pagoDiferido = true;
@@ -3919,6 +3924,7 @@
 							//getConceptos(vm.filterAddPromotion.filterProgram[0].OfertaEducativa, concepto);//RJP
 						}else{
 							vm.colegiaturaInscripcion = false;
+							vm.muestra_seleccionar_pagos_oe = false;
 							vm.asignarPromocion.conceptoPromocion;
 							vm.asignarPromocion.cantidadPagosOE = false;
 							// vm.asignarPromocion.cantidadPagos = null;
@@ -3950,7 +3956,7 @@
 					}
 
 					function pagosOEConcepto(){
-						if(vm.asignarPromocion.cantidadPagosOE == true){
+						/*if(vm.asignarPromocion.cantidadPagosOE == true){
 							if( vm.asignarPromocion.pagoUnico == true ) {
 								vm.asignarPromocion.pagoUnico = false;
 							}
@@ -3958,18 +3964,35 @@
 								vm.asignarPromocion.pagoDiferido = false;
 							}
 							vm.asignarPromocion.cantidadPagos = 0;
-						}
+						}*/
+						vm.colegiaturaInscripcion = vm.colegiaturaInscripcion == true ? false : !vm.colegiaturaInscripcion;
+						//proAgP.asignarPromocion.cantidadPagosOE = proAgP.asignarPromocion.cantidadPagosOE ? false: !proAgP.asignarPromocion.cantidadPagosOE;
+						if (!vm.estado_anterior_pagos_oe)
+							vm.estado_anterior_pagos_oe = {
+								cantidadPagos: vm.asignarPromocion.cantidadPagos
+							}
+						
+						vm.asignarPromocion.cantidadPagos = vm.estado_anterior_pagos_oe.cantidadPagos
 					};
 
 					function tipoPagoUnico(){
-						if( vm.asignarPromocion.pagoUnico == true ){
+						/* if( vm.asignarPromocion.pagoUnico == true ){
 
 							vm.asignarPromocion.cantidadPagos = '1';
 
 							if( vm.asignarPromocion.pagoDiferido == true ){
 								vm.asignarPromocion.pagoDiferido = false;
 							}
+						} */
+
+						
+						if(!vm.asignarPromocion.pagoUnico){
+							vm.asignarPromocion.cantidadPagos = undefined;
+							return;
 						}
+
+						vm.asignarPromocion.cantidadPagos = '1';
+						vm.asignarPromocion.pagoDiferido = false;
 					};
 
 					function tipoPagoDiferido(){

--- a/force-app/main/default/pages/PRO_Layout.page
+++ b/force-app/main/default/pages/PRO_Layout.page
@@ -3398,7 +3398,7 @@
 						if( promotion.NombreConcepto__r
 						&& ( promotion.NombreConcepto__r.Name == 'Colegiatura' 
 						|| promotion.NombreConcepto__r.Name == 'Reinscripción' ) || promotion.SeleccionarCantidadPagosOE__c){
-							proAgP.muestra_seleccionar_pagos_oe = true;
+							vm.muestra_seleccionar_pagos_oe = true;
 							vm.colegiaturaInscripcion = true;
 							vm.asignarPromocion.cantidadPagosOE = ( promotion.SeleccionarCantidadPagosOE__c  ) ? promotion.SeleccionarCantidadPagosOE__c : false;
 						}
@@ -3461,7 +3461,7 @@
 						console.log(FUNC_NAME + 'periodoFechaInicio:', periodoFechaInicio);
 						console.log(FUNC_NAME + 'promocionFechaFin:', promocionFechaFin);
 						console.log(FUNC_NAME + 'periodoFechaFin:', periodoFechaFin);
-						if (promocionFechaInicio < periodoFechaInicio) {
+						if (promocionFechaFin < periodoFechaInicio) {
 							RequestFactory.toastMessageWarning('La Fecha Inicio de Vigencia de la promoción debe ser mayor o igual a la fecha de inicio del Periodo seleccionado');
 							banderaExito = false;
 						} else if (promocionFechaInicio >= periodoFechaFin) {
@@ -3911,7 +3911,7 @@
 					function tipoConcepto(concepto){
 						console.log('tipoConcepto::concepto::',concepto);
 						console.log('tipoConcepto::filterAddPromotion::',vm.filterAddPromotion);
-						if (vm.filterAddPromotion && vm.filterAddPromotion.filterProgram && vm.filterAddPromotion.filterProgram.length == 1 && (concepto.HeredarCantidadPagosColegiaturaOE__c == true || concepto.HeredarCantidadPagosInscripcionOE__c == true)) {
+						if (vm.filterAddPromotion && vm.filterAddPromotion.filterProgram && (concepto.HeredarCantidadPagosColegiaturaOE__c == true || concepto.HeredarCantidadPagosInscripcionOE__c == true)) {
 							console.log('tipoConcepto::entraif::');
 							vm.muestra_seleccionar_pagos_oe = true;
 							vm.colegiaturaInscripcion = true;

--- a/force-app/main/default/pages/PRO_Layout.page
+++ b/force-app/main/default/pages/PRO_Layout.page
@@ -3393,7 +3393,7 @@
 
 						if( promotion.NombreConcepto__r
 						&& ( promotion.NombreConcepto__r.Name == 'Colegiatura' 
-						|| promotion.NombreConcepto__r.Name == 'Reinscripción' ) ){
+						|| promotion.NombreConcepto__r.Name == 'Reinscripción' ) || promotion.SeleccionarCantidadPagosOE__c){
 
 							vm.colegiaturaInscripcion = true;
 							vm.asignarPromocion.cantidadPagosOE = ( promotion.SeleccionarCantidadPagosOE__c  ) ? promotion.SeleccionarCantidadPagosOE__c : false;


### PR DESCRIPTION
Se corrige el comportamiento de

1. No permite guardar promoción con conceptos que heredan pagos de la `colegiatura` o la `inscripción`
2. El comportamiento de los checks en la parte inferior del componente para crear una nueva promoción. Tanto en el estado en el que se crea como cuando se edita
3. No renderizaba de forma correcta la configuración de una promoción al momento de editar una promoción